### PR TITLE
Adding an invalidate time option for authenticators to require login in new browser sessions

### DIFF
--- a/__tests__/UALProvider.js
+++ b/__tests__/UALProvider.js
@@ -38,15 +38,31 @@ describe('UALProvider', () => {
       expect(spy).toHaveBeenCalled()
     })
 
-    it('that attempts auto-login if authenticator type is in localStorage', async () => {
+    it('that attempts auto-login if authenticator type is in localStorage and not invalidated', async () => {
       localStorage.setItem('UALAccountName', 'Example')
       localStorage.setItem('UALLoggedInAuthType', 'Scatter')
+      const invalidateAt = new Date();
+      invalidateAt.setSeconds(invalidateAt.getSeconds() + 100);
+      window.localStorage.setItem('UALInvalidateAt', invalidateAt)
+
       const spy = jest.spyOn(wrapper.instance(), 'getAuthenticatorInstance')
       wrapper.instance().componentDidMount()
       expect(spy).toHaveBeenCalled()
     })
 
     it('that does not attempt to auto-login if localStorage is empty', async () => {
+      const spy = jest.spyOn(wrapper.instance(), 'getAuthenticatorInstance')
+      wrapper.instance().componentDidMount()
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('that does not attempt to auto-login if localStorage is outdated', async () => {
+      localStorage.setItem('UALAccountName', 'Example')
+      localStorage.setItem('UALLoggedInAuthType', 'Scatter')
+      const invalidateAt = new Date();
+      invalidateAt.setSeconds(invalidateAt.getSeconds() - 1);
+      window.localStorage.setItem('UALInvalidateAt', invalidateAt)
+
       const spy = jest.spyOn(wrapper.instance(), 'getAuthenticatorInstance')
       wrapper.instance().componentDidMount()
       expect(spy).not.toHaveBeenCalled()
@@ -138,15 +154,20 @@ describe('UALProvider', () => {
     it('that clears the localStorage', () => {
       localStorage.setItem('UALAccountName', 'Example')
       localStorage.setItem('UALLoggedInAuthType', 'Scatter')
+      const invalidateAt = new Date();
+      invalidateAt.setSeconds(invalidateAt.getSeconds() - 1);
+      window.localStorage.setItem('UALInvalidateAt', invalidateAt)
       const activeAuthenticator = wrapper.state().availableAuthenticators[0]
       wrapper.setState({
         activeAuthenticator,
       })
       expect(localStorage.hasOwnProperty('UALAccountName')).toBe(true)
       expect(localStorage.hasOwnProperty('UALLoggedInAuthType')).toBe(true)
+      expect(localStorage.hasOwnProperty('UALInvalidateAt')).toBe(true)
       wrapper.state().logout()
       expect(localStorage.hasOwnProperty('UALAccountName')).toBe(false)
       expect(localStorage.hasOwnProperty('UALLoggedInAuthType')).toBe(false)
+      expect(localStorage.hasOwnProperty('UALInvalidateAt')).toBe(false)
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-icons": "3.4.0",
     "react-tooltip": "3.9.2",
     "styled-components": "4.1.3",
-    "universal-authenticator-library": "0.1.4"
+    "universal-authenticator-library": "0.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/components/provider/UALProvider.js
+++ b/src/components/provider/UALProvider.js
@@ -239,6 +239,7 @@ export class UALProvider extends Component {
         const availableCheck = setInterval(() => {
           if (!authenticator.isLoading()) {
             clearInterval(availableCheck)
+            if (!authenticator.shouldAutoLogin()) return;
             // Only Ledger requires an account name
             if (accountName) {
               submitAccountForLogin(accountName, authenticator)

--- a/src/components/provider/UALProvider.js
+++ b/src/components/provider/UALProvider.js
@@ -232,9 +232,7 @@ export class UALProvider extends Component {
     const invalidate = window.localStorage.getItem('UALInvalidateAt')
     const accountName = window.localStorage.getItem('UALAccountName')
     if (type && invalidate && new Date(invalidate) <= new Date()) {
-      window.localStorage.removeItem('UALLoggedInAuthType');
-      window.localStorage.removeItem('UALInvalidateAt');
-      window.localStorage.removeItem('UALAccountName');
+      this.clearCache();
       type = undefined;
     }
     const ual = new UAL(chains, appName, authenticators)
@@ -337,6 +335,7 @@ export class UALProvider extends Component {
   clearCache = () => {
     window.localStorage.removeItem('UALLoggedInAuthType')
     window.localStorage.removeItem('UALAccountName')
+    window.localStorage.removeItem('UALInvalidateAt')
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5827,10 +5827,10 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
-universal-authenticator-library@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/universal-authenticator-library/-/universal-authenticator-library-0.1.4.tgz#e3f31d743780077184475089a8a9b57300316161"
-  integrity sha512-1nU8W7yAc+ZQ+MlJA1gGKnGylSNyyaA2wC4Zy1RqtJo+asDYcNTc4gAySYp19TYhfdF0WwQXeve7SVuodbMHJA==
+universal-authenticator-library@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universal-authenticator-library/-/universal-authenticator-library-0.2.0.tgz#6b609e5a3d6c8c2ad209ccc9f06f4bb6be4bc807"
+  integrity sha512-uukf31lXIB/nRaiO/Z1Aag48ZLWtiX3kd05XIz6QWwjuQbprLOzgesGgMeVxQNTCgTDHGxwtE/mzkZ+5R1x8qw==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Change Description
Users that are already authenticated are re-logged in on refresh to emulate normal user sessions on other sites.  Adding an optional invalidate time option for authenticators to cause users to re-authenticate after the time has elapsed and a new browser session occurs.

Resolves https://github.com/EOSIO/universal-authenticator-library/issues/48

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
