### PR TITLE
Minimizing the amount of authenticator initializations

### DIFF
--- a/src/components/provider/UALProvider.js
+++ b/src/components/provider/UALProvider.js
@@ -112,8 +112,6 @@ export class UALProvider extends Component {
        * @return {Void}
        */
       showModal: () => {
-        const { availableAuthenticators } = this.state
-        availableAuthenticators.forEach(auth => auth.reset())
         this.setState({ modal: true })
       },
       /**
@@ -229,8 +227,8 @@ export class UALProvider extends Component {
     const type = window.localStorage.getItem('UALLoggedInAuthType')
     const accountName = window.localStorage.getItem('UALAccountName')
     const ual = new UAL(chains, appName, authenticators)
+    const { availableAuthenticators, autoLoginAuthenticator } = ual.getAuthenticators()
     try {
-      const { availableAuthenticators } = ual.getAuthenticators()
       if (type) {
         const authenticator = this.getAuthenticatorInstance(type, availableAuthenticators)
         if (!authenticator) {
@@ -255,7 +253,6 @@ export class UALProvider extends Component {
       const errType = UALErrorType.Login
       console.warn(new UALError(msg, errType, e, source))
     } finally {
-      const { availableAuthenticators, autoLoginAuthenticator } = ual.getAuthenticators()
       this.fetchAuthenticators(availableAuthenticators, autoLoginAuthenticator)
     }
   }


### PR DESCRIPTION
## Change Description
Due to multiple Authenticator initializations, the integration with Scatter was not working correctly.  ual-reactjs-renderer was initializing the ual-scatter Authenticator three times, which was calling connect() multiple times to scatterjs-core.  There was an issue with old websockets being closed but utilized in scatterjs (https://github.com/GetScatter/scatter-js/issues/156) but that has since been resolved.  Fixing the multiple initializations/connections on ual-reactjs-renderer's end here as well to avoid this issue in the future or with other Authenticators.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
