### PR TITLE
Fixes bug described https://github.com/EOSIO/ual-reactjs-renderer/iss…

### DIFF
--- a/src/components/provider/UALProvider.js
+++ b/src/components/provider/UALProvider.js
@@ -167,7 +167,7 @@ export class UALProvider extends Component {
           const users = await authenticator.login()
           const accountName = await users[0].getAccountName()
           if (!isAutoLogin) {
-            window.localStorage.setItem('UALLoggedInAuthType', authenticator.constructor.name)
+            window.localStorage.setItem('UALLoggedInAuthType', authenticator.getStyle().text)
             this.setUALInvalidateAt(authenticator)
           }
           broadcastStatus({
@@ -195,7 +195,7 @@ export class UALProvider extends Component {
        */
       submitAccountForLogin: async (accountInput, authenticator) => {
         const { broadcastStatus } = this.state
-        const authenticatorName = authenticator.constructor.name
+        const authenticatorName = authenticator.getStyle().text
         broadcastStatus({
           loading: true,
           message: authenticator.requiresGetKeyConfirmation()


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Description of issue #92 from aaroncox:
-----------
When using the ual-reactjs-renderer within an application that uses a minification build process, the names of the authenticators are getting mangled and corrupting the local storage value for UALLoggedInAuthType. The value saved in local storage ends up being the minified value (like n) and causes session persistence to break.

This is happening because it's currently using the constructor value which seems to be a valid target for mangling
-----------

A note on priority: This is blocking my adoption of UAL for the Acueos (Compound Finance protocol implementation on EOS) dApp.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
