### PR TITLE
Improve bundle size by replacing react-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "docs": "jsdoc src -r -d docs"
   },
   "dependencies": {
+    "@meronex/icons": "^4.0.0",
     "i18next": "14.0.1",
     "i18next-browser-languagedetector": "2.2.4",
     "prop-types": "15.7.2",
     "react": "16.13.0",
     "react-dom": "16.13.0",
-    "react-icons": "3.9.0",
     "react-tooltip": "3.9.2",
     "styled-components": "4.4.1",
     "universal-authenticator-library": "0.3.0"

--- a/src/components/authentication/UALAuthButton.js
+++ b/src/components/authentication/UALAuthButton.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Tooltip from 'react-tooltip'
-import { FaChevronRight, FaDownload } from 'react-icons/fa'
-import { IoMdInformationCircleOutline } from 'react-icons/io'
+import FaChevronRight from '@meronex/icons/fa/FaChevronRight'
+import FaDownload from '@meronex/icons/fa/FaDownload'
+import IoMdInformationCircleOutline from '@meronex/icons/ios/IosInformationCircleOutline'
 
 import { UALLoadingIcon } from '../misc/UALLoadingIcon'
 import { boxTitles } from '../../constants/box'

--- a/src/components/info/UALErrorMessage.js
+++ b/src/components/info/UALErrorMessage.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { UALError } from 'universal-authenticator-library'
-
-import { IoMdInformationCircleOutline } from 'react-icons/io'
+import IoMdInformationCircleOutline from '@meronex/icons/ios/IosInformationCircleOutline'
 
 import { base } from '../../styles/base'
 import { errorMessage } from '../../styles/error'

--- a/src/components/info/UALLearnMore.js
+++ b/src/components/info/UALLearnMore.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
-import { IoMdInformationCircleOutline, IoMdCloseCircleOutline } from 'react-icons/io'
+import IoMdInformationCircleOutline from '@meronex/icons/ios/IosInformationCircleOutline'
+import IoMdCloseCircleOutline from '@meronex/icons/ios/IosCloseCircleOutline'
 import i18n from '../../i18n'
 
 import { base } from '../../styles/base'

--- a/src/components/misc/UALExitButton.js
+++ b/src/components/misc/UALExitButton.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-
-import { FaTimes } from 'react-icons/fa'
+import FaTimes from '@meronex/icons/fa/FaTimes'
 
 import { exitWrapper, exit, exitHover } from '../../styles/buttons/exit'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,6 +1216,14 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@meronex/icons@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@meronex/icons/-/icons-4.0.0.tgz#26e089a8a4ec176a5b6778fd54fcdd25b4746c67"
+  integrity sha512-WnoxUT02qawZSvsoPSwe7YOqOk0APysIHugiD3dYdc/QNeoigN4PD8mmmtmZFKlv8/Z7eERub0BmPkWcJ1BI+w==
+  dependencies:
+    camelcase "^5.0.0"
+    ncp "^2.0.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
@@ -4555,6 +4563,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
+
 nearley@^2.7.10:
   version "2.19.4"
   resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.19.4.tgz#7518cbdd7d0e8e08b5f82841b9edb0126239c8b1"
@@ -5061,13 +5074,6 @@ react-dom@16.13.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.0"
-
-react-icons@3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.9.0.tgz#89a00f20a0e02e6bfd899977eaf46eb4624239d5"
-  integrity sha512-gKbYKR+4QsD3PmIHLAM9TDDpnaTsr3XZeK1NTAb6WQQ+gxEdJ0xuCgLq0pxXdS7Utg2AIpcVhM1ut/jlDhcyNg==
-  dependencies:
-    camelcase "^5.0.0"
 
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"


### PR DESCRIPTION
Tree-shaking with react-icons using babel does not work and several megabytes of icon data is included, see issue #103.

## Change Description

- Removes react-icons and uses a different package that works with tree-shaking. [See here](https://www.npmjs.com/package/@meronex/icons#credits-and-motivation-for-the-fork)

Reduces bundle size [from 2MB](https://bundlephobia.com/result?p=ual-reactjs-renderer@0.3.1) to [319 KB](https://bundlephobia.com/result?p=@cmichel/ual-reactjs-renderer@0.4.0).

## API Changes

None

## Documentation Additions

None