### PR TITLE
Compile esm version for better tree shaking in consuming projects

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,10 @@
 {
-	presets: ["@babel/preset-env", "@babel/preset-react"],
-	plugins: ["@babel/plugin-proposal-class-properties", "@babel/plugin-transform-regenerator"]
+	"presets": ["@babel/preset-env", "@babel/preset-react"],
+	"plugins": ["@babel/plugin-proposal-class-properties", "@babel/plugin-transform-regenerator"],
+	"env": {
+		"esm" : {
+			"presets": [["@babel/preset-env", {"modules": false}], "@babel/preset-react"],
+			"plugins": ["@babel/plugin-proposal-class-properties", "@babel/plugin-transform-regenerator"],
+		}
+	}
 }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("./dist/cjs/index.js");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "ual-reactjs-renderer",
   "version": "0.3.1",
-  "main": "dist/index.js",
+  "main": "index.js",
+  "module": "dist/esm/index.js",
   "author": {
     "name": "block.one",
     "url": "https://block.one/"
@@ -12,7 +13,9 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf dist && babel src --out-dir dist --source-maps",
+    "build": "rm -rf dist && npm run build:cjs && npm run build:esm",
+    "build:cjs": "babel src --out-dir dist/cjs --source-maps",
+    "build:esm": "babel src --out-dir dist/esm --source-maps --env-name esm",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src",
     "test": "jest",
     "prepare": "yarn build",


### PR DESCRIPTION
Without including the esm versions of the files it's not possible for consuming projects to tree shake out unused parts of libs. 
That means over 1MB of react-icons gets pulled in for just the few icons that this package uses.

This change cut my package size (that depends on this lib) by over 500k!

<img width="553" alt="Screen Shot 2021-04-20 at Apr 20, 05 22 09 PM" src="https://user-images.githubusercontent.com/2205/115471692-01450e00-a1fe-11eb-9313-a92a1425f48b.png">


